### PR TITLE
Fixed windows build. Fails FUNC_CrossPlatformFileCheck like POSIX system...

### DIFF
--- a/include/maidsafe/drive/directory_handler.h
+++ b/include/maidsafe/drive/directory_handler.h
@@ -449,13 +449,6 @@ void DirectoryHandler<Storage>::RenameDifferentParent(
   assert(old_parent.first && old_parent.second && new_parent);
   auto file(old_parent.first->RemoveChild(old_relative_path.filename()));
 
-// #ifndef MAIDSAFE_WIN32
-//   struct stat old;
-//   old.st_ctime = meta_data.attributes.st_ctime;
-//   old.st_mtime = meta_data.attributes.st_mtime;
-//   time(&meta_data.attributes.st_mtime);
-//   meta_data.attributes.st_ctime = meta_data.attributes.st_mtime;
-// #endif
   if (IsDirectory(file)) {
     auto directory(Get<Directory>(old_relative_path));
     DeleteAllVersions(directory.get());
@@ -480,26 +473,9 @@ void DirectoryHandler<Storage>::RenameDifferentParent(
   file->SetParent(new_parent);
   new_parent->AddChild(file);
 
-#ifdef MAIDSAFE_WIN32
-  GetSystemTimeAsFileTime(&old_parent.second->meta_data.last_write_time);
-  // if (new_relative_path.parent_path() != old_relative_path.parent_path().parent_path()) {
-  //   try {
-  //     if (old_grandparent.listing)
-  //       old_grandparent.listing->UpdateChild(old_parent_meta_data);
-  //   }
-  //   catch (const std::exception&) {}  // Non-critical
-  //   Put(old_grandparent, old_relative_path.parent_path().parent_path());
-  // }
-#else
-  // old_parent_meta_data.attributes.st_ctime = old_parent_meta_data.attributes.st_mtime =
-  //     meta_data.attributes.st_mtime;
-  // if (IsDirectory(file)) {
-  //   --old_parent_meta_data.attributes.st_nlink;
-  //   ++new_parent_meta_data.attributes.st_nlink;
-  //   new_parent_meta_data.attributes.st_ctime = new_parent_meta_data.attributes.st_mtime =
-  //       old_parent_meta_data.attributes.st_mtime;
-  // }
-#endif
+  old_parent.second->meta_data.last_write_time =
+    old_parent.second->meta_data.last_access_time =
+    common::Clock::now();
 }
 
 template <typename Storage>

--- a/include/maidsafe/drive/win_drive.h
+++ b/include/maidsafe/drive/win_drive.h
@@ -680,9 +680,9 @@ void CbfsDrive<Storage>::CbFsGetFileInfo(
   }
 
   *file_exists = true;
-  *creation_time = ToFileTime(file->meta_data.creation_time);
-  *last_access_time = ToFileTime(file->meta_data.last_access_time);
-  *last_write_time = ToFileTime(file->meta_data.last_write_time);
+  *creation_time = detail::ToFileTime(file->meta_data.creation_time);
+  *last_access_time = detail::ToFileTime(file->meta_data.last_access_time);
+  *last_write_time = detail::ToFileTime(file->meta_data.last_write_time);
   // if (file->meta_data.size < file->meta_data.allocation_size)
   //   file->meta_data.size = file->meta_data.allocation_size;
   // else if (file->meta_data.allocation_size < file->meta_data.size)
@@ -745,12 +745,12 @@ void CbfsDrive<Storage>::CbFsEnumerateDirectory(
     int64_t* end_of_file, int64_t* allocation_size, int64_t* /*file_id*/ OPTIONAL,
     PDWORD file_attributes) {
   SCOPED_PROFILE
-  auto cbfs_drive(detail::GetDrive<Storage>(sender));
-  auto relative_path(detail::GetRelativePath<Storage>(cbfs_drive, directory_info));
-  std::wstring mask_str(mask);
+  const auto cbfs_drive(detail::GetDrive<Storage>(sender));
+  const auto relative_path(detail::GetRelativePath<Storage>(cbfs_drive, directory_info));
+  const std::wstring mask_str(mask);
   LOG(kInfo) << "CbFsEnumerateDirectory - " << relative_path << " mask: "
              << WstringToString(mask_str) << " restart: " << std::boolalpha << (restart != 0);
-  bool exact_match(mask_str != L"*");
+  const bool exact_match(mask_str != L"*");
   *file_found = false;
 
   std::shared_ptr<detail::Directory> directory(nullptr);
@@ -764,7 +764,7 @@ void CbfsDrive<Storage>::CbFsEnumerateDirectory(
     throw ECBFSError(ERROR_FILE_NOT_FOUND);
   }
 
-  const detail::File* file(nullptr);
+  std::shared_ptr<const detail::Path> file(nullptr);
   if (exact_match) {
     while (!(*file_found)) {
       file = directory->GetChildAndIncrementCounter();
@@ -783,9 +783,9 @@ void CbfsDrive<Storage>::CbFsEnumerateDirectory(
     // this is done.
     wcscpy(file_name, file->meta_data.name.wstring().c_str());
     *file_name_length = static_cast<DWORD>(file->meta_data.name.wstring().size());
-    *creation_time = ToFileTime(file->meta_data.creation_time);
-    *last_access_time = ToFileTime(file->meta_data.last_access_time);
-    *last_write_time = ToFileTime(file->meta_data.last_write_time);
+    *creation_time = detail::ToFileTime(file->meta_data.creation_time);
+    *last_access_time = detail::ToFileTime(file->meta_data.last_access_time);
+    *last_write_time = detail::ToFileTime(file->meta_data.last_write_time);
     *end_of_file = file->meta_data.size;
     *allocation_size = file->meta_data.allocation_size;
     *file_attributes = file->meta_data.attributes;
@@ -909,7 +909,7 @@ void CbfsDrive<Storage>::CbFsSetFileAttributes(
       detail::SetFiletime(file->meta_data.last_access_time, last_access_time);
     changed |= detail::SetFiletime(file->meta_data.last_write_time, last_write_time);
     if (changed) {
-      file->meta_data.last_status_time = detail::common::Clock::now();
+      file->meta_data.last_status_time = common::Clock::now();
       file->ScheduleForStoring();
     }
   }

--- a/src/maidsafe/drive/tests/directory_test.cc
+++ b/src/maidsafe/drive/tests/directory_test.cc
@@ -39,6 +39,7 @@
 #include "maidsafe/drive/meta_data.h"
 #include "maidsafe/drive/directory.h"
 #include "maidsafe/drive/utils.h"
+#include "maidsafe/drive/symlink.h"
 #include "maidsafe/drive/tests/test_utils.h"
 
 namespace fs = boost::filesystem;
@@ -98,9 +99,7 @@ class DirectoryTest : public testing::Test {
         = file->meta_data.last_access_time
         = file->meta_data.last_write_time
         = common::Clock::now();
-#ifdef MAIDSAFE_WIN32
-    file.meta_data.attributes = FILE_ATTRIBUTE_DIRECTORY;
-#endif
+
     *file->meta_data.directory_id =
         Identity(crypto::Hash<crypto::SHA512>((*main_test_dir_ / path).string()));
     EXPECT_NO_THROW(directory->AddChild(file));
@@ -454,9 +453,6 @@ TEST_F(DirectoryTest, BEH_SerialiseAndParse) {
         = file->meta_data.last_write_time
         = common::Clock::now();
     if (is_dir) {
-#ifdef MAIDSAFE_WIN32
-      file.meta_data.attributes = FILE_ATTRIBUTE_DIRECTORY;
-#endif
       EXPECT_NO_THROW(directory->AddChild(file));
     } else {
       file->meta_data.size = RandomUint32();

--- a/src/maidsafe/drive/win_drive.cc
+++ b/src/maidsafe/drive/win_drive.cc
@@ -70,10 +70,12 @@ bool SetAttributes(DWORD& attributes, DWORD new_value) {
 }
 
 bool SetFiletime(common::Clock::time_point& filetime, PFILETIME new_value) {
-  if (new_value && filetime.dwLowDateTime != new_value->dwLowDateTime &&
-      filetime.dwHighDateTime != new_value->dwHighDateTime) {
-    filetime = ToTimePoint(*new_value);
-    return true;
+  if (new_value) {
+    const auto t = ToTimePoint(*new_value);
+    if (filetime != t) {
+        filetime = t;
+        return true;
+    }
   }
   return false;
 }
@@ -103,6 +105,7 @@ common::Clock::time_point ToTimePoint(const FILETIME& input) {
   // See ToFileTime
   using namespace std::chrono;
   const ULONGLONG filetimeTicks = 100ULL;
+  const ULONGLONG chronoTicks = 1ULL;
   const ULONGLONG epochDifference = 11644473600ULL * (chronoTicks / filetimeTicks);
   ULONGLONG filetime = ((ULONGLONG)(input.dwHighDateTime) << 32) + input.dwLowDateTime;
   ULONGLONG stamp = (filetime - epochDifference) * (filetimeTicks / chronoTicks);


### PR DESCRIPTION
Made a separate pull request so encapsulate metadata patch could _potentially_ be merged before the larger windows permissions patch.
